### PR TITLE
feat: Add NO_OUTPUT sentinel for processor filtering

### DIFF
--- a/src/producer_graph/_processor.py
+++ b/src/producer_graph/_processor.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 DONE_SENTINEL = object()
+NO_OUTPUT = object()
 
 type BasicTransformCallable = Callable[[Any], Awaitable[Any] | Any]
 type MultiTransformCallbale = Callable[[Any], Iterable[Any] | AsyncIterable[Any]]
@@ -85,7 +86,7 @@ class _TransformProcessorBase(_ProcessorBase):
 
             result = await self._process_item(input_item)
 
-            if output_queue:
+            if result is not NO_OUTPUT and output_queue:
                 await self._produce_output(result, output_queue)
 
             if input_queue and input_item is not DONE_SENTINEL:

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -6,6 +6,7 @@ import pytest
 
 from producer_graph._processor import (
     DONE_SENTINEL,
+    NO_OUTPUT,
     BatchingProcessor,
     MultiOutputProcessor,
     StandardProcessor,
@@ -173,3 +174,33 @@ async def test_batching_processor_custom_function():
     input_data = [1, 2, 1, 3, 2, 4]
     results = await run_processor_test(processor, input_data)
     assert results == [{1, 2, 3}, {2, 4}]
+
+
+@pytest.mark.asyncio
+async def test_standard_processor_no_output():
+    """Test StandardProcessor correctly filters out NO_OUTPUT sentinels."""
+
+    def filtering_transform(x):
+        if x % 2 == 0:
+            return NO_OUTPUT
+        return x * 2
+
+    processor = StandardProcessor(filtering_transform)
+    input_data = [1, 2, 3, 4, 5]
+    results = await run_processor_test(processor, input_data)
+    assert results == [2, 6, 10]
+
+
+@pytest.mark.asyncio
+async def test_multi_output_processor_no_output():
+    """Test MultiOutputProcessor correctly filters out NO_OUTPUT sentinels."""
+
+    def filtering_multi_transform(x):
+        if x % 2 == 0:
+            return NO_OUTPUT
+        return [x, x]
+
+    processor = MultiOutputProcessor(filtering_multi_transform)
+    input_data = [1, 2, 3, 4, 5]
+    results = await run_processor_test(processor, input_data)
+    assert results == [1, 1, 3, 3, 5, 5]


### PR DESCRIPTION
This commit introduces a `NO_OUTPUT` sentinel that can be returned by a processor's transform function to indicate that no output should be produced for a given input item.

- A new `NO_OUTPUT` object is defined in `_processor.py`.
- The `_TransformProcessorBase` is updated to check for this sentinel. If a transform returns `NO_OUTPUT`, the result is discarded and not passed to the output queue.
- New tests are added to `tests/test_processor.py` to verify that both `StandardProcessor` and `MultiOutputProcessor` correctly handle and filter out the `NO_OUTPUT` sentinel.

co-authored-by: erik.abair@bearbrains.work